### PR TITLE
Fix err Cannot set property 'password' of undefined

### DIFF
--- a/hydra-cli.js
+++ b/hydra-cli.js
@@ -114,7 +114,7 @@ class Program {
             }
           };
           if (this.configData.redisPassword && this.configData.redisPassword !== '') {
-            conf.redis.password = this.configData.redisPassword;
+            conf.hydra.redis.password = this.configData.redisPassword;
           }
 
           let tid = setTimeout(() => {


### PR DESCRIPTION
Throwing error when configuration has a redis password

err Cannot set property 'password' of undefined
Warning, hydra-cli is not configured.
Use the hydra-cli config command.