### PR TITLE
Don't error if hydra parses the result as json but extract it and log it, Closes #30  Closes #37

### DIFF
--- a/hydra-cli.js
+++ b/hydra-cli.js
@@ -626,7 +626,7 @@ class Program {
           });
           hydra.makeAPIRequest(msg)
             .then((res) => {
-              if((res.payLoad ?? res) == undefined) {
+              if ((res.payLoad ?? res) == undefined) {
                 console.trace(`Error parsing response from service.`);
                 this.exitApp();
                 return;
@@ -636,11 +636,15 @@ class Program {
                 const internalKeys = Object.keys(consoleOutput)
                 const resultObj = {};
                 Object.entries(res).forEach(([key, val]) => {
-                  if(!internalKeys.includes(key) && !(key == "result" && Object.entries(val).length == 0)) resultObj[key] = val;
+                  if (!internalKeys.includes(key) && !(key == "result" && Object.entries(val).length == 0)) {
+                    resultObj[key] = val;
+                  }
                 })
                 return resultObj;
               })()
-              if(res.payLoad != undefined) delete res.payLoad;
+              if (res.payLoad != undefined) {
+                delete res.payLoad;
+              }
               this.displayJSON(consoleOutput);
               this.exitApp();
             })
@@ -662,7 +666,7 @@ class Program {
       });
       hydra.makeAPIRequest(msg)
         .then((res) => {
-          if((res.payLoad ?? res) == undefined) {
+          if ((res.payLoad ?? res) == undefined) {
             console.trace(`Error parsing response from service.`);
             this.exitApp();
             return;
@@ -672,11 +676,15 @@ class Program {
             const internalKeys = Object.keys(consoleOutput)
             const resultObj = {};
             Object.entries(res).forEach(([key, val]) => {
-              if(!internalKeys.includes(key) && !(key == "result" && Object.entries(val).length == 0)) resultObj[key] = val;
+              if (!internalKeys.includes(key) && !(key == "result" && Object.entries(val).length == 0)) {
+                resultObj[key] = val;
+              }
             })
             return resultObj;
           })()
-          if(res.payLoad != undefined) delete res.payLoad;
+          if (res.payLoad != undefined) {
+            delete res.payLoad;
+          }
           this.displayJSON(consoleOutput);
           this.exitApp();
         })

--- a/hydra-cli.js
+++ b/hydra-cli.js
@@ -626,9 +626,22 @@ class Program {
           });
           hydra.makeAPIRequest(msg)
             .then((res) => {
-              res.result = res.payLoad.toString('utf8');
-              delete res.payLoad;
-              this.displayJSON(res);
+              if((res.payLoad ?? res) == undefined) {
+                console.trace(`Error parsing response from service.`);
+                this.exitApp();
+                return;
+              }
+              const consoleOutput = {statusCode: res.statusCode, statusMessage: res.statusMessage, statusDescription: res.statusDescription, headers: res.headers}
+              consoleOutput.result = res.payLoad != null ? res.payLoad.toString(): (() => {
+                const internalKeys = Object.keys(consoleOutput)
+                const resultObj = {};
+                Object.entries(res).forEach(([key, val]) => {
+                  if(!internalKeys.includes(key) && !(key == "result" && Object.entries(val).length == 0)) resultObj[key] = val;
+                })
+                return resultObj;
+              })()
+              if(res.payLoad != undefined) delete res.payLoad;
+              this.displayJSON(consoleOutput);
               this.exitApp();
             })
             .catch((err) => {
@@ -649,9 +662,22 @@ class Program {
       });
       hydra.makeAPIRequest(msg)
         .then((res) => {
-          res.result = res.payLoad.toString('utf8');
-          delete res.payLoad;
-          this.displayJSON(res);
+          if((res.payLoad ?? res) == undefined) {
+            console.trace(`Error parsing response from service.`);
+            this.exitApp();
+            return;
+          }
+          const consoleOutput = {statusCode: res.statusCode, statusMessage: res.statusMessage, statusDescription: res.statusDescription, headers: res.headers}
+          consoleOutput.result = res.payLoad != null ? res.payLoad.toString(): (() => {
+            const internalKeys = Object.keys(consoleOutput)
+            const resultObj = {};
+            Object.entries(res).forEach(([key, val]) => {
+              if(!internalKeys.includes(key) && !(key == "result" && Object.entries(val).length == 0)) resultObj[key] = val;
+            })
+            return resultObj;
+          })()
+          if(res.payLoad != undefined) delete res.payLoad;
+          this.displayJSON(consoleOutput);
           this.exitApp();
         })
         .catch((err) => {


### PR DESCRIPTION
This pr adds a handler for object responses to the code and extracts them into their own param. #31 just removed the handler entirely, which is a solution but I think extracting it would be more readable to the user.

The error was caused because of line 1287-1290 in https://github.com/pnxtech/hydra/blob/master/index.js